### PR TITLE
Fix insurance related issues

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -28,11 +28,6 @@ public interface Logic {
     ObservableList<ReadOnlyInsurance> getFilteredInsuranceList();
     //@@author
 
-    //@@author RSJunior37
-    /** Returns an unmodifiable view of the list of insurances */
-    ObservableList<ReadOnlyInsurance> getInsuranceList();
-    //@@author
-
     /** Returns the list of input entered by the user, encapsulated in a {@code ListElementPointer} object */
     ListElementPointer getHistorySnapshot();
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -23,6 +23,11 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<ReadOnlyPerson> getFilteredPersonList();
 
+    //@@author OscarWang114
+    /** Returns an unmodifiable view of the list of insurances */
+    ObservableList<ReadOnlyInsurance> getFilteredInsuranceList();
+    //@@author
+
     //@@author RSJunior37
     /** Returns an unmodifiable view of the list of insurances */
     ObservableList<ReadOnlyInsurance> getInsuranceList();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -104,13 +104,6 @@ public class LogicManager extends ComponentManager implements Logic {
     }
     //
 
-    //@@author RSJunior37
-    @Override
-    public ObservableList<ReadOnlyInsurance> getInsuranceList() {
-        return model.getInsuranceList();
-    }
-    //@@author
-
     @Override
     public ListElementPointer getHistorySnapshot() {
         return new ListElementPointer(history.getHistory());

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -97,6 +97,13 @@ public class LogicManager extends ComponentManager implements Logic {
         return model.getFilteredPersonList();
     }
 
+    //@@author OscarWang114
+    @Override
+    public ObservableList<ReadOnlyInsurance> getFilteredInsuranceList() {
+        return model.getFilteredInsuranceList();
+    }
+    //
+
     //@@author RSJunior37
     @Override
     public ObservableList<ReadOnlyInsurance> getInsuranceList() {

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -54,7 +54,7 @@ public class SelectCommand extends Command {
     public CommandResult execute() throws CommandException {
 
         List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
-        List<ReadOnlyInsurance> insuranceList = model.getInsuranceList();
+        List<ReadOnlyInsurance> insuranceList = model.getFilteredInsuranceList();
 
         if (panelChoice == PanelChoice.PERSON && targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -122,6 +122,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         // TODO: the tags master list will be updated even though the below line fails.
         // This can cause the tags master list to have additional tags that are not tagged to any person
         // in the person list.
+        // TODO: consider reverse the order?
         persons.add(newPerson);
         persons.sortPersons();
         syncWithUpdate();
@@ -203,6 +204,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public boolean removePerson(ReadOnlyPerson key) throws PersonNotFoundException {
         if (persons.remove(key)) {
+
             syncWithUpdate();
             return true;
         } else {
@@ -231,11 +233,11 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void syncMasterLifeInsuranceMap() {
         lifeInsuranceMap.forEach((id, insurance) -> {
+            insurance.resetAllInsurancePerson();
             String owner = insurance.getOwner().getName();
             String insured = insurance.getInsured().getName();
             String beneficiary = insurance.getBeneficiary().getName();
             persons.forEach(person -> {
-                //person.clearLifeInsuranceIds();
                 if (person.getName().fullName.equals(owner)) {
                     insurance.setOwner(person);
                     person.addLifeInsuranceIds(id);
@@ -250,6 +252,7 @@ public class AddressBook implements ReadOnlyAddressBook {
                 }
             });
         });
+        lifeInsuranceMap.syncMappedListWithInternalMap();
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -15,6 +15,9 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<ReadOnlyPerson> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<ReadOnlyInsurance> PREDICATE_SHOW_ALL_INSURANCES = unused -> true;
+
     /** Clears existing backing model and replaces with the provided new data. */
     void resetData(ReadOnlyAddressBook newData);
 
@@ -43,11 +46,9 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<ReadOnlyPerson> getFilteredPersonList();
 
-    //@@author RSJunior37
-    /**
-     * Returns an unmodifiable view of the insurances list
-     */
-    ObservableList<ReadOnlyInsurance> getInsuranceList();
+    //@@author OscarWang114
+    /** Returns an unmodifiable view of the filtered insurance list */
+    ObservableList<ReadOnlyInsurance> getFilteredInsuranceList();
     //@@author
 
     /**
@@ -56,5 +57,9 @@ public interface Model {
      */
     void updateFilteredPersonList(Predicate<ReadOnlyPerson> predicate);
 
-    void updateInsuranceList(Predicate<ReadOnlyInsurance> predicate);
+    /**
+     * Updates the filter of the filtered insurance list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredInsuranceList(Predicate<ReadOnlyInsurance> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -26,6 +26,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     private final AddressBook addressBook;
     private final FilteredList<ReadOnlyPerson> filteredPersons;
+    private final FilteredList<ReadOnlyInsurance> filteredInsurances;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -38,6 +39,7 @@ public class ModelManager extends ComponentManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredInsurances = new FilteredList<>(this.addressBook.getInsuranceList());
     }
 
     public ModelManager() {
@@ -77,7 +79,6 @@ public class ModelManager extends ComponentManager implements Model {
     public void updatePerson(ReadOnlyPerson target, ReadOnlyPerson editedPerson)
             throws DuplicatePersonException, PersonNotFoundException {
         requireAllNonNull(target, editedPerson);
-
         addressBook.updatePerson(target, editedPerson);
         indicateAddressBookChanged();
     }
@@ -85,15 +86,27 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public synchronized void addInsurance(ReadOnlyInsurance insurance) {
         addressBook.addInsurance(insurance);
+        updateFilteredInsuranceList(PREDICATE_SHOW_ALL_INSURANCES);
         indicateAddressBookChanged();
     }
     //=========== Insurance List Accessors ==================================================================
-    //@@author RSJunior37
+    //@author OscarWang114
+    /**
+     * Returns an unmodifiable view of the list of {@code ReadOnlyPerson} backed by the internal list of
+     * {@code addressBook}
+     */
     @Override
-    public ObservableList<ReadOnlyInsurance> getInsuranceList() {
-        return addressBook.getInsuranceList();
+    public ObservableList<ReadOnlyInsurance> getFilteredInsuranceList() {
+        return FXCollections.unmodifiableObservableList(filteredInsurances);
     }
-    //@@author
+
+
+    @Override
+    public void updateFilteredInsuranceList(Predicate<ReadOnlyInsurance> predicate) {
+        requireNonNull(predicate);
+        filteredInsurances.setPredicate(predicate);
+    }
+    //
 
     //=========== Filtered Person List Accessors =============================================================
 
@@ -111,12 +124,6 @@ public class ModelManager extends ComponentManager implements Model {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
     }
-
-    @Override
-    public void updateInsuranceList(Predicate<ReadOnlyInsurance> predicate) {
-
-    }
-
 
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/seedu/address/model/insurance/LifeInsurance.java
+++ b/src/main/java/seedu/address/model/insurance/LifeInsurance.java
@@ -111,6 +111,20 @@ public class LifeInsurance implements ReadOnlyInsurance {
         this.expiryDateString = new SimpleStringProperty(source.getExpiryDateString());
     }
 
+    /**
+     * Resets the value of the owner, insured, beneficiary of this insurance. Every new {@code InsurancePerson}
+     * object is constructed with the {@code name} field assigned and the {@code person} field unassigned.
+     */
+    public void resetAllInsurancePerson() {
+        String ownerName = this.roleToPersonNameMap.get(Roles.OWNER);
+        String insuredName = this.roleToPersonNameMap.get(Roles.INSURED);
+        String beneficiaryName = this.roleToPersonNameMap.get(Roles.BENEFICIARY);
+        this.owner = new SimpleObjectProperty<>(new InsurancePerson(ownerName));
+        this.insured = new SimpleObjectProperty<>(new InsurancePerson(insuredName));
+        this.beneficiary = new SimpleObjectProperty<>(new InsurancePerson(beneficiaryName));
+
+    }
+
     @Override
     public ObjectProperty<UUID> idProperty() {
         return id;

--- a/src/main/java/seedu/address/model/insurance/UniqueLifeInsuranceMap.java
+++ b/src/main/java/seedu/address/model/insurance/UniqueLifeInsuranceMap.java
@@ -4,13 +4,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.insurance.exceptions.DuplicateInsuranceException;
 import seedu.address.model.insurance.exceptions.InsuranceNotFoundException;
@@ -26,7 +26,8 @@ import seedu.address.model.insurance.exceptions.InsuranceNotFoundException;
  */
 public class UniqueLifeInsuranceMap {
 
-    private final HashMap<UUID, LifeInsurance> internalMap = new HashMap<>();
+    private final ObservableMap<UUID, LifeInsurance> internalMap = FXCollections.observableHashMap();
+    private final ObservableList<ReadOnlyInsurance> internalList = FXCollections.observableArrayList();
 
     /**
      * Returns true if the map contains an equivalent UUID as the given argument.
@@ -79,6 +80,7 @@ public class UniqueLifeInsuranceMap {
     public void setInsurances(UniqueLifeInsuranceMap replacement) {
         this.internalMap.clear();
         this.internalMap.putAll(replacement.internalMap);
+        syncMappedListWithInternalMap();
     }
 
     public void setInsurances(Map<UUID, ? extends ReadOnlyInsurance> insurances) throws DuplicateInsuranceException {
@@ -89,6 +91,16 @@ public class UniqueLifeInsuranceMap {
         setInsurances(replacement);
     }
 
+    /**
+     * Ensures that every insurance in the internalList:
+     * contains the same exact same collections of insurances as that of the insuranceMap.
+     */
+    public void syncMappedListWithInternalMap() {
+        this.internalList.clear();
+        this.internalList.setAll(this.internalMap.values());
+    }
+    //author
+
     //@@author RSJunior37
     /**
      * Accessor to insurance list
@@ -96,7 +108,7 @@ public class UniqueLifeInsuranceMap {
      */
     public ObservableList<ReadOnlyInsurance> asObservableList() {
         assert CollectionUtil.elementsAreUnique(internalMap.values());
-        return FXCollections.unmodifiableObservableList(FXCollections.observableArrayList(internalMap.values()));
+        return FXCollections.unmodifiableObservableList(internalList);
     }
     //@@author
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -143,8 +143,7 @@ public class MainWindow extends UiPart<Region> {
             if (event.getCode().equals(KeyCode.TAB)) {
                 if (commandTextField.isFocused()) {
                     searchTextField.requestFocus();
-                }
-                else {
+                } else {
                     commandTextField.requestFocus();
                 }
                 event.consume();
@@ -160,7 +159,7 @@ public class MainWindow extends UiPart<Region> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        insuranceListPanel = new InsuranceListPanel(logic.getInsuranceList());
+        insuranceListPanel = new InsuranceListPanel(logic.getFilteredInsuranceList());
         insuranceListPanelPlaceholder.getChildren().add(insuranceListPanel.getRoot());
 
         insuranceProfilePanel = new InsuranceProfilePanel();

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -137,7 +137,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<ReadOnlyInsurance> getInsuranceList() {
+        public ObservableList<ReadOnlyInsurance> getFilteredInsuranceList() {
             fail("This method should not be called.");
             return null;
         }
@@ -147,7 +147,7 @@ public class AddCommandTest {
             fail("This method should not be called.");
         }
 
-        public void updateInsuranceList(Predicate<ReadOnlyInsurance> predicate) {
+        public void updateFilteredInsuranceList(Predicate<ReadOnlyInsurance> predicate) {
             fail("This method should not be called.");
         }
     }


### PR DESCRIPTION
- Fixed the issue that the insurance list is not updated after adding an insurance.
- Fixed the issue that after a person is deleted, he/she can still be accessed with the related insurances.

Remark:
- I renamed the original functions `getInsuranceList` and `updateInsuranceList` to `getFilteredInsuranceList` and `updateFilteredInsuranceList` because I believe we may have time to implement filters for the insurance list (shouldn't be hard at all). If ultimately we failed to do so, I will restore the original functions.