### PR TITLE
Ensure there are no duplicate insurance contract names inside LISA

### DIFF
--- a/data/addressbook.xml
+++ b/data/addressbook.xml
@@ -9,14 +9,10 @@
         <gender>MALE</gender>
         <tagged>friends</tagged>
         <lifeInsuranceId>c77ca792-fbe9-44bc-b43b-f0423d0e1fc8</lifeInsuranceId>
+        <lifeInsuranceId>e21b7a14-8994-4fd5-9b00-fd64e41dcac1</lifeInsuranceId>
         <lifeInsuranceId>ea91ce18-4a4f-415a-a688-62621c241108</lifeInsuranceId>
         <lifeInsuranceId>067e6162-3b6f-4ae2-a171-2470b63dff00</lifeInsuranceId>
-        <lifeInsuranceId>e21b7a14-8994-4fd5-9b00-fd64e41dcac1</lifeInsuranceId>
-        <lifeInsuranceId>bed5144d-da16-4fb3-ae96-904cb84e66d4</lifeInsuranceId>
-        <lifeInsuranceId>82afe1a0-cb3a-49f9-a8b9-cb24af313182</lifeInsuranceId>
-        <lifeInsuranceId>9893449b-b534-437f-a570-67fb94fca493</lifeInsuranceId>
-        <lifeInsuranceId>3c78cb78-8110-444e-b0fa-8bc3fcb18a6c</lifeInsuranceId>
-        <lifeInsuranceId>828fd2fa-cd59-4b33-92be-61cd93a045f0</lifeInsuranceId>
+        <lifeInsuranceId>d78e2780-112a-466b-abd2-400a5bf0f288</lifeInsuranceId>
     </persons>
     <persons>
         <name>Bernice Yu</name>
@@ -27,9 +23,9 @@
         <gender>MALE</gender>
         <tagged>colleagues</tagged>
         <tagged>friends</tagged>
+        <lifeInsuranceId>bb96325f-5e40-4056-85b1-ce5df6b273d6</lifeInsuranceId>
         <lifeInsuranceId>ea91ce18-4a4f-415a-a688-62621c241108</lifeInsuranceId>
         <lifeInsuranceId>067e6162-3b6f-4ae2-a171-2470b63dff00</lifeInsuranceId>
-        <lifeInsuranceId>bb96325f-5e40-4056-85b1-ce5df6b273d6</lifeInsuranceId>
     </persons>
     <persons>
         <name>Charlotte Oliveiro</name>
@@ -49,8 +45,8 @@
         <dob>30 Jan 1997</dob>
         <gender>MALE</gender>
         <tagged>family</tagged>
-        <lifeInsuranceId>a5d63bc4-a975-4994-bb19-d73f8dfc8f97</lifeInsuranceId>
         <lifeInsuranceId>bb96325f-5e40-4056-85b1-ce5df6b273d6</lifeInsuranceId>
+        <lifeInsuranceId>a5d63bc4-a975-4994-bb19-d73f8dfc8f97</lifeInsuranceId>
     </persons>
     <persons>
         <name>Irfan Ibrahim</name>
@@ -81,11 +77,7 @@
         <lifeInsuranceId>c77ca792-fbe9-44bc-b43b-f0423d0e1fc8</lifeInsuranceId>
         <lifeInsuranceId>ad4dc852-e6bb-44e9-800e-fa8a8964e7f1</lifeInsuranceId>
         <lifeInsuranceId>a5d63bc4-a975-4994-bb19-d73f8dfc8f97</lifeInsuranceId>
-        <lifeInsuranceId>bed5144d-da16-4fb3-ae96-904cb84e66d4</lifeInsuranceId>
-        <lifeInsuranceId>82afe1a0-cb3a-49f9-a8b9-cb24af313182</lifeInsuranceId>
-        <lifeInsuranceId>9893449b-b534-437f-a570-67fb94fca493</lifeInsuranceId>
-        <lifeInsuranceId>3c78cb78-8110-444e-b0fa-8bc3fcb18a6c</lifeInsuranceId>
-        <lifeInsuranceId>828fd2fa-cd59-4b33-92be-61cd93a045f0</lifeInsuranceId>
+        <lifeInsuranceId>d78e2780-112a-466b-abd2-400a5bf0f288</lifeInsuranceId>
     </persons>
     <persons>
         <name>Pujitha Desiraju</name>
@@ -121,35 +113,21 @@
                 <insured>Another person not in Lisa</insured>
                 <beneficiary>Bernice Yu</beneficiary>
                 <premium>50.0</premium>
-                <contractPath>cheapContract.pdf</contractPath>
+                <contractName>AlexYeoh-Cheap.pdf</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2018</expiryDate>
             </value>
         </entry>
         <entry>
-            <key>82afe1a0-cb3a-49f9-a8b9-cb24af313182</key>
+            <key>d78e2780-112a-466b-abd2-400a5bf0f288</key>
             <value>
-                <id>add86e82-ffbf-441e-843e-b6d11b416a5c</id>
+                <id>0b45a7c5-1097-40b4-9a03-1157b391796b</id>
                 <insuranceName>Term</insuranceName>
                 <owner>Alex Yeoh</owner>
                 <insured>Oscar</insured>
                 <beneficiary>Oscar</beneficiary>
                 <premium>500.0</premium>
-                <contractPath>pdf</contractPath>
-                <signingDate>01 Nov 2017</signingDate>
-                <expiryDate>01 Nov 2018</expiryDate>
-            </value>
-        </entry>
-        <entry>
-            <key>3c78cb78-8110-444e-b0fa-8bc3fcb18a6c</key>
-            <value>
-                <id>c2de267e-91e2-4cc5-a4b7-8fd02120cbea</id>
-                <insuranceName>Term</insuranceName>
-                <owner>Alex Yeoh</owner>
-                <insured>Oscar</insured>
-                <beneficiary>Oscar</beneficiary>
-                <premium>500.0</premium>
-                <contractPath>pdf</contractPath>
+                <contractName>TermLife</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2018</expiryDate>
             </value>
@@ -163,7 +141,7 @@
                 <insured>David Li</insured>
                 <beneficiary>Roy Balakrishnan</beneficiary>
                 <premium>8500.0</premium>
-                <contractPath>WholeLife.pdf</contractPath>
+                <contractName>BerniceYu-WholeLife.pdf</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2117</expiryDate>
             </value>
@@ -177,7 +155,7 @@
                 <insured>Bernice Yu</insured>
                 <beneficiary>Charlotte Oliveiro</beneficiary>
                 <premium>100.0</premium>
-                <contractPath>contract.pdf</contractPath>
+                <contractName>AlexYeoh-Normal.pdf</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2018</expiryDate>
             </value>
@@ -191,7 +169,7 @@
                 <insured>Oscar</insured>
                 <beneficiary>David Li</beneficiary>
                 <premium>1000.0</premium>
-                <contractPath>contract.pdf</contractPath>
+                <contractName>Oscar-Normal.pdf</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2018</expiryDate>
             </value>
@@ -205,23 +183,9 @@
                 <insured>Roy Balakrishnan</insured>
                 <beneficiary>Mary Jane</beneficiary>
                 <premium>500.0</premium>
-                <contractPath>expensiveContract.pdf</contractPath>
+                <contractName>NotInLisa-Expensive.pdf</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2020</expiryDate>
-            </value>
-        </entry>
-        <entry>
-            <key>828fd2fa-cd59-4b33-92be-61cd93a045f0</key>
-            <value>
-                <id>1edc1deb-96f3-4651-a881-87f5b0db372c</id>
-                <insuranceName>Term</insuranceName>
-                <owner>Alex Yeoh</owner>
-                <insured>Oscar</insured>
-                <beneficiary>Oscar</beneficiary>
-                <premium>500.0</premium>
-                <contractPath>pdf</contractPath>
-                <signingDate>01 Nov 2017</signingDate>
-                <expiryDate>01 Nov 2018</expiryDate>
             </value>
         </entry>
         <entry>
@@ -233,23 +197,9 @@
                 <insured>John Doe</insured>
                 <beneficiary>Mary Jane</beneficiary>
                 <premium>600.0</premium>
-                <contractPath>TermLife.pdf</contractPath>
+                <contractName>TermLife.pdf</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2037</expiryDate>
-            </value>
-        </entry>
-        <entry>
-            <key>bed5144d-da16-4fb3-ae96-904cb84e66d4</key>
-            <value>
-                <id>38b2bc00-9dce-468e-8e01-2bec687bcd5e</id>
-                <insuranceName>Term</insuranceName>
-                <owner>Alex Yeoh</owner>
-                <insured>Oscar</insured>
-                <beneficiary>Oscar</beneficiary>
-                <premium>500.0</premium>
-                <contractPath>pdf</contractPath>
-                <signingDate>01 Nov 2017</signingDate>
-                <expiryDate>01 Nov 2018</expiryDate>
             </value>
         </entry>
         <entry>
@@ -261,21 +211,7 @@
                 <insured>Oscar</insured>
                 <beneficiary>Oscar</beneficiary>
                 <premium>1000.0</premium>
-                <contractPath>contract.pdf</contractPath>
-                <signingDate>01 Nov 2017</signingDate>
-                <expiryDate>01 Nov 2018</expiryDate>
-            </value>
-        </entry>
-        <entry>
-            <key>9893449b-b534-437f-a570-67fb94fca493</key>
-            <value>
-                <id>0f6e4b41-e0f9-4015-a82c-e694e60ee1ad</id>
-                <insuranceName>Term</insuranceName>
-                <owner>Alex Yeoh</owner>
-                <insured>Oscar</insured>
-                <beneficiary>Oscar</beneficiary>
-                <premium>500.0</premium>
-                <contractPath>pdf</contractPath>
+                <contractName>AlexYeoh-Prudential.pdf</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2018</expiryDate>
             </value>
@@ -289,7 +225,7 @@
                 <insured>Oscar</insured>
                 <beneficiary>Oscar</beneficiary>
                 <premium>1000.0</premium>
-                <contractPath>contract.pdf</contractPath>
+                <contractName>Oscar-AXA.pdf</contractName>
                 <signingDate>01 Nov 2017</signingDate>
                 <expiryDate>01 Nov 2018</expiryDate>
             </value>

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -810,9 +810,9 @@ In the case that the file exist in the project folder, the entry for contract fi
          if (isFileExists(insuranceFile)) {
              activateLinkToInsuranceFile();
          } else {
-             contractPath.getStyleClass().clear();
-             contractPath.getStyleClass().add("missing-file");
-             contractPath.setOnMouseClicked(new EventHandler<MouseEvent>() {
+             contractName.getStyleClass().clear();
+             contractName.getStyleClass().add("missing-file");
+             contractName.setOnMouseClicked(new EventHandler<MouseEvent>() {
                  @Override
                  public void handle(MouseEvent event) {
                      FileChooser.ExtensionFilter extFilter =
@@ -846,9 +846,9 @@ Upon successful retrieval of the file, or adding of the file if it does not exis
 [source,java]
 ----
 private void activateLinkToInsuranceFile() {
-         contractPath.getStyleClass().clear();
-         contractPath.getStyleClass().add("valid-file");
-         contractPath.setOnMouseClicked(event -> {
+         contractName.getStyleClass().clear();
+         contractName.getStyleClass().add("valid-file");
+         contractName.setOnMouseClicked(event -> {
              try {
                  Desktop.getDesktop().open(insuranceFile);
              } catch (IOException ee) {

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -40,7 +40,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 5, 0, true);
+    public static final Version VERSION = new Version(1, 5, 0, false);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -50,7 +50,7 @@ public class AddCommand extends UndoableCommand {
     //@@author
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in LISA";
 
     private final Person toAdd;
 
@@ -178,8 +178,7 @@ public class AddCommand extends UndoableCommand {
             }
 
             // state check
-            AddCommand.AddPersonOptionalFieldDescriptor a =
-                    (AddCommand.AddPersonOptionalFieldDescriptor) other;
+            AddCommand.AddPersonOptionalFieldDescriptor a = (AddCommand.AddPersonOptionalFieldDescriptor) other;
 
             return getPhone().equals(a.getPhone())
                     && getEmail().equals(a.getEmail())

--- a/src/main/java/seedu/address/logic/commands/AddLifeInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLifeInsuranceCommand.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BENEFICIARY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -15,38 +15,42 @@ import java.util.List;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.insurance.LifeInsurance;
 import seedu.address.model.insurance.ReadOnlyInsurance;
+import seedu.address.model.insurance.exceptions.DuplicateInsuranceContractNameException;
+import seedu.address.model.insurance.exceptions.DuplicateInsuranceException;
 import seedu.address.model.person.ReadOnlyPerson;
 
 //@@author OscarWang114
 /**
- * Creates an insurance in Lisa
+ * Creates a life insurance in Lisa
  */
 public class AddLifeInsuranceCommand extends UndoableCommand {
     public static final String[] COMMAND_WORDS = {"addli", "ali", "+li"};
     public static final String COMMAND_WORD = "addli";
 
     public static final String MESSAGE_USAGE = concatenateCommandWords(COMMAND_WORDS)
-            + ": Adds an insurance to Lisa. "
+            + ": Adds a life insurance to Lisa. "
             + "Parameters: "
             + PREFIX_NAME + "INSURANCE_NAME "
             + PREFIX_OWNER + "OWNER "
             + PREFIX_INSURED + "INSURED "
             + PREFIX_BENEFICIARY + "BENEFICIARY "
-            + PREFIX_CONTRACT + "CONTRACT "
             + PREFIX_PREMIUM + "PREMIUM "
             + PREFIX_SIGNING_DATE + "SIGNING_DATE "
-            + PREFIX_EXPIRY_DATE + "EXPIRY_DATE\n"
+            + PREFIX_EXPIRY_DATE + "EXPIRY_DATE"
+            + PREFIX_CONTRACT_NAME + " CONTRACT_NAME\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Life Insurance "
+            + PREFIX_NAME + "Term Life "
             + PREFIX_OWNER + "Alex Yeoh "
             + PREFIX_INSURED + "John Doe "
             + PREFIX_BENEFICIARY + "Mary Jane "
-            + PREFIX_CONTRACT + "normal_plan.pdf "
-            + PREFIX_PREMIUM + "500 "
-            + PREFIX_SIGNING_DATE + "01 11 2017 "
-            + PREFIX_EXPIRY_DATE + "01 11 2018 ";
+            + PREFIX_PREMIUM + "600 "
+            + PREFIX_SIGNING_DATE + "17 11 2017 "
+            + PREFIX_EXPIRY_DATE + "17 11 2037 "
+            + PREFIX_CONTRACT_NAME + "AlexYeoh-TermLife";
 
     public static final String MESSAGE_SUCCESS = "New insurance added: %1$s";
+    public static final String MESSAGE_DUPLICATE_INSURANCE_CONTRACT_FILE =
+            "This insurance contract file already exists in LISA";
 
     private final LifeInsurance lifeInsurance;
 
@@ -62,7 +66,7 @@ public class AddLifeInsuranceCommand extends UndoableCommand {
      * life insurance are inside the person list by matching their names case-insensitively. If matches,
      * set the person as the owner, insured, or beneficiary accordingly. Note that a person can
      */
-    public void isAnyPersonInList(List<ReadOnlyPerson> list, LifeInsurance lifeInsurance) {
+    private void isAnyPersonInList(List<ReadOnlyPerson> list, LifeInsurance lifeInsurance) {
         String ownerName = lifeInsurance.getOwner().getName();
         String insuredName = lifeInsurance.getInsured().getName();
         String beneficiaryName = lifeInsurance.getBeneficiary().getName();
@@ -85,8 +89,14 @@ public class AddLifeInsuranceCommand extends UndoableCommand {
         requireNonNull(model);
         List<ReadOnlyPerson> personList = model.getFilteredPersonList();
         isAnyPersonInList(personList, lifeInsurance);
-        model.addLifeInsurance(lifeInsurance);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, lifeInsurance));
+        try {
+            model.addLifeInsurance(lifeInsurance);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, lifeInsurance));
+        } catch (DuplicateInsuranceException die) {
+            throw new AssertionError("AddressBooks should not have duplicate insurances");
+        } catch (DuplicateInsuranceContractNameException dicne) {
+            throw new CommandException(MESSAGE_DUPLICATE_INSURANCE_CONTRACT_FILE);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddLifeInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLifeInsuranceCommand.java
@@ -28,7 +28,7 @@ public class AddLifeInsuranceCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "addli";
 
     public static final String MESSAGE_USAGE = concatenateCommandWords(COMMAND_WORDS)
-            + ": Adds a life insurance to Lisa. "
+            + ": Adds a life insurance to Lisa.\n"
             + "Parameters: "
             + PREFIX_NAME + "INSURANCE_NAME "
             + PREFIX_OWNER + "OWNER "
@@ -36,8 +36,8 @@ public class AddLifeInsuranceCommand extends UndoableCommand {
             + PREFIX_BENEFICIARY + "BENEFICIARY "
             + PREFIX_PREMIUM + "PREMIUM "
             + PREFIX_SIGNING_DATE + "SIGNING_DATE "
-            + PREFIX_EXPIRY_DATE + "EXPIRY_DATE"
-            + PREFIX_CONTRACT_NAME + " CONTRACT_NAME\n"
+            + PREFIX_EXPIRY_DATE + "EXPIRY_DATE "
+            + PREFIX_CONTRACT_NAME + "CONTRACT_NAME\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Term Life "
             + PREFIX_OWNER + "Alex Yeoh "

--- a/src/main/java/seedu/address/logic/parser/AddLifeInsuranceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLifeInsuranceCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BENEFICIARY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -35,10 +35,10 @@ public class AddLifeInsuranceCommandParser implements Parser<AddLifeInsuranceCom
         ArgumentMultimap argMultimap;
         argMultimap = ArgumentTokenizer.tokenize(
                 args, PREFIX_NAME, PREFIX_OWNER, PREFIX_INSURED, PREFIX_BENEFICIARY, PREFIX_PREMIUM,
-                PREFIX_CONTRACT, PREFIX_SIGNING_DATE, PREFIX_EXPIRY_DATE);
+                PREFIX_CONTRACT_NAME, PREFIX_SIGNING_DATE, PREFIX_EXPIRY_DATE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_OWNER, PREFIX_INSURED, PREFIX_BENEFICIARY,
-                PREFIX_PREMIUM, PREFIX_CONTRACT, PREFIX_SIGNING_DATE, PREFIX_EXPIRY_DATE)) {
+                PREFIX_PREMIUM, PREFIX_CONTRACT_NAME, PREFIX_SIGNING_DATE, PREFIX_EXPIRY_DATE)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddLifeInsuranceCommand.MESSAGE_USAGE));
         }
@@ -49,7 +49,7 @@ public class AddLifeInsuranceCommandParser implements Parser<AddLifeInsuranceCom
             String insured = ParserUtil.parseNameForInsurance(argMultimap.getValue(PREFIX_INSURED)).get();
             String beneficiary = ParserUtil.parseNameForInsurance(argMultimap.getValue(PREFIX_BENEFICIARY)).get();
             Double premium = ParserUtil.parsePremium(argMultimap.getValue(PREFIX_PREMIUM)).get();
-            String contract = ParserUtil.parseContract(argMultimap.getValue(PREFIX_CONTRACT)).get();
+            String contract = ParserUtil.parseContract(argMultimap.getValue(PREFIX_CONTRACT_NAME)).get();
             LocalDate signingDate = new DateParser().parse(
                     ParserUtil.parseContract(argMultimap.getValue(PREFIX_SIGNING_DATE)).get()
             );

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -21,7 +21,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_INSURED = new Prefix("i/");
     public static final Prefix PREFIX_BENEFICIARY = new Prefix("b/");
     public static final Prefix PREFIX_PREMIUM = new Prefix("pr/");
-    public static final Prefix PREFIX_CONTRACT = new Prefix("c/");
+    public static final Prefix PREFIX_CONTRACT_NAME = new Prefix("c/");
     public static final Prefix PREFIX_SIGNING_DATE = new Prefix("sd/");
     public static final Prefix PREFIX_EXPIRY_DATE = new Prefix("ed/");
     public static final Prefix PREFIX_GENDER = new Prefix("g/");

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -15,6 +15,7 @@ import seedu.address.commons.function.ThrowingConsumer;
 import seedu.address.model.insurance.LifeInsurance;
 import seedu.address.model.insurance.ReadOnlyInsurance;
 import seedu.address.model.insurance.UniqueLifeInsuranceMap;
+import seedu.address.model.insurance.exceptions.DuplicateInsuranceContractNameException;
 import seedu.address.model.insurance.exceptions.DuplicateInsuranceException;
 import seedu.address.model.insurance.exceptions.InsuranceNotFoundException;
 import seedu.address.model.person.Person;
@@ -73,7 +74,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     //@@author OscarWang114
-    public void setLifeInsurances(Map<UUID, ReadOnlyInsurance> insurances) throws DuplicateInsuranceException {
+    public void setLifeInsurances(Map<UUID, ReadOnlyInsurance> insurances)
+            throws DuplicateInsuranceException, DuplicateInsuranceContractNameException {
         this.lifeInsuranceMap.setInsurances(insurances);
     }
 
@@ -98,7 +100,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         try {
             setPersons(newData.getPersonList());
             persons.sortPersons();
-        } catch (DuplicatePersonException e) {
+        } catch (DuplicatePersonException dpe) {
             assert false : "AddressBooks should not have duplicate persons";
         }
 
@@ -107,14 +109,16 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         try {
             setLifeInsurances(newData.getLifeInsuranceMap());
-        } catch (DuplicateInsuranceException e) {
+        } catch (DuplicateInsuranceException die) {
             assert false : "AddressBooks should not have duplicate insurances";
+        } catch (DuplicateInsuranceContractNameException dicne) {
+            assert false : "AddressBooks should not have duplicate insurance contract names";
         }
         syncMasterLifeInsuranceMap();
 
         try {
             syncMasterPersonList();
-        } catch (InsuranceNotFoundException e) {
+        } catch (InsuranceNotFoundException infe) {
             assert false : "AddressBooks should not contain id that doesn't match to an insurance";
         }
     }
@@ -167,14 +171,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      *Adds an insurance to the address book.
      */
-    public void addInsurance(ReadOnlyInsurance i) {
+    public void addInsurance(ReadOnlyInsurance i)
+            throws DuplicateInsuranceException, DuplicateInsuranceContractNameException {
         UUID id = UUID.randomUUID();
         LifeInsurance lifeInsurance = new LifeInsurance(i);
-        try {
-            lifeInsuranceMap.put(id, lifeInsurance);
-        } catch (DuplicateInsuranceException e) {
-            assert false : "AddressBooks should not have duplicate insurances";
-        }
+        lifeInsuranceMap.put(id, lifeInsurance);
         syncWithUpdate();
     }
     //@@author
@@ -244,6 +245,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      *  - links to its owner, insured, and beneficiary {@code Person} if they exist in master person list respectively
      */
     public void syncMasterLifeInsuranceMap() {
+
         lifeInsuranceMap.forEach((id, insurance) -> {
             insurance.resetAllInsurancePerson();
             String owner = insurance.getOwner().getName();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -4,6 +4,8 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.insurance.ReadOnlyInsurance;
+import seedu.address.model.insurance.exceptions.DuplicateInsuranceContractNameException;
+import seedu.address.model.insurance.exceptions.DuplicateInsuranceException;
 import seedu.address.model.insurance.exceptions.InsuranceNotFoundException;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
@@ -42,7 +44,8 @@ public interface Model {
             throws DuplicatePersonException, PersonNotFoundException;
 
     /** Adds the given insurance */
-    void addLifeInsurance(ReadOnlyInsurance insurance);
+    void addLifeInsurance(ReadOnlyInsurance insurance)
+            throws DuplicateInsuranceException, DuplicateInsuranceContractNameException;
 
     /**
      * Replaces the given life insurance {@code target} with {@code editedLifeInsurance}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,8 @@ import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
 import seedu.address.model.insurance.ReadOnlyInsurance;
+import seedu.address.model.insurance.exceptions.DuplicateInsuranceContractNameException;
+import seedu.address.model.insurance.exceptions.DuplicateInsuranceException;
 import seedu.address.model.insurance.exceptions.InsuranceNotFoundException;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
@@ -86,7 +88,8 @@ public class ModelManager extends ComponentManager implements Model {
 
     //@author OscarWang114
     @Override
-    public synchronized void addLifeInsurance(ReadOnlyInsurance insurance) {
+    public synchronized void addLifeInsurance(ReadOnlyInsurance insurance)
+            throws DuplicateInsuranceException, DuplicateInsuranceContractNameException {
         addressBook.addInsurance(insurance);
         updateFilteredInsuranceList(PREDICATE_SHOW_ALL_INSURANCES);
         indicateAddressBookChanged();

--- a/src/main/java/seedu/address/model/insurance/LifeInsurance.java
+++ b/src/main/java/seedu/address/model/insurance/LifeInsurance.java
@@ -239,11 +239,7 @@ public class LifeInsurance implements ReadOnlyInsurance {
     }
     //@author
 
-    //@author OscarWang114
-    public void setContractName(String contractName) {
-        this.contractName.set(requireNonNull(contractName));
-    }
-
+    //@@author OscarWang114
     @Override
     public StringProperty contractNameProperty() {
         return contractName;
@@ -286,13 +282,9 @@ public class LifeInsurance implements ReadOnlyInsurance {
 
     @Override
     public boolean equals(Object other) {
-        //TODO: Increase the validity of equals
         return other == this // short circuit if same object
                 || (other instanceof LifeInsurance // instanceof handles nulls
-                && ((LifeInsurance) other).getInsuranceName().equals(this.insuranceName)
-                && ((LifeInsurance) other).premiumString.equals(this.premiumString)
-                && ((LifeInsurance) other).signingDate.equals(this.signingDate)
-                && ((LifeInsurance) other).expiryDate.equals(this.expiryDate)); // state check
+                && this.isSameStateAs((ReadOnlyInsurance) other));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/insurance/LifeInsurance.java
+++ b/src/main/java/seedu/address/model/insurance/LifeInsurance.java
@@ -35,7 +35,7 @@ public class LifeInsurance implements ReadOnlyInsurance {
     private ObjectProperty<InsurancePerson> beneficiary;
     private DoubleProperty premium;
     private StringProperty premiumString;
-    private StringProperty contractPath;
+    private StringProperty contractName;
     private StringProperty signingDateString;
     private StringProperty expiryDateString;
 
@@ -50,7 +50,7 @@ public class LifeInsurance implements ReadOnlyInsurance {
      * Constructor for {@code XmlAdaptedLifeInsurance.toModelType()}
      */
     public LifeInsurance(String id, String insuranceName, String owner, String insured, String beneficiary,
-                         Double premium, String contractPath, String signingDateInput, String expiryDateInput)
+                         Double premium, String contractName, String signingDateInput, String expiryDateInput)
             throws IllegalValueException {
         this.id = new SimpleObjectProperty<>(UUID.fromString(id));
         this.insuranceName = new SimpleStringProperty(insuranceName);
@@ -62,7 +62,7 @@ public class LifeInsurance implements ReadOnlyInsurance {
         this.insured = new SimpleObjectProperty<>(new InsurancePerson(insured));
         this.beneficiary = new SimpleObjectProperty<>(new InsurancePerson(beneficiary));
         this.premium = new SimpleDoubleProperty(premium);
-        this.contractPath = new SimpleStringProperty(contractPath);
+        this.contractName = new SimpleStringProperty(contractName);
         this.signingDate = new DateParser().parse(signingDateInput);
         this.signingDateString = new SimpleStringProperty(this.signingDate.format(DateParser.DATE_FORMAT));
         this.expiryDate = new DateParser().parse(expiryDateInput);
@@ -74,8 +74,8 @@ public class LifeInsurance implements ReadOnlyInsurance {
      * Constructor for {@code AddLifeInsuranceCommand}
      */
     public LifeInsurance(String insuranceName, String owner, String insured, String beneficiary, Double premium,
-                         String contractPath, LocalDate signingDate, LocalDate expiryDate) {
-        requireAllNonNull(owner, insured, beneficiary, premium, contractPath);
+                         String contractName, LocalDate signingDate, LocalDate expiryDate) {
+        requireAllNonNull(owner, insured, beneficiary, premium, contractName);
         this.id = new SimpleObjectProperty<>(UUID.randomUUID());
         this.insuranceName = new SimpleStringProperty(insuranceName);
         this.roleToPersonNameMap = new EnumMap<>(Roles.class);
@@ -86,7 +86,7 @@ public class LifeInsurance implements ReadOnlyInsurance {
         this.insured = new SimpleObjectProperty<>(new InsurancePerson(insured));
         this.beneficiary = new SimpleObjectProperty<>(new InsurancePerson(beneficiary));
         this.premium = new SimpleDoubleProperty(premium);
-        this.contractPath = new SimpleStringProperty(contractPath);
+        this.contractName = new SimpleStringProperty(contractName);
         this.signingDate = signingDate;
         this.signingDateString = new SimpleStringProperty(this.signingDate.format(DateParser.DATE_FORMAT));
         this.expiryDate = expiryDate;
@@ -109,7 +109,7 @@ public class LifeInsurance implements ReadOnlyInsurance {
         this.beneficiary = new SimpleObjectProperty<>(source.getBeneficiary());
         this.premium = new SimpleDoubleProperty(source.getPremium());
         this.premiumString = new SimpleStringProperty(this.getPremiumString());
-        this.contractPath = new SimpleStringProperty(source.getContractPath());
+        this.contractName = new SimpleStringProperty(source.getContractName());
         this.signingDateString = new SimpleStringProperty(source.getSigningDateString());
         this.expiryDateString = new SimpleStringProperty(source.getExpiryDateString());
     }
@@ -240,18 +240,18 @@ public class LifeInsurance implements ReadOnlyInsurance {
     //@author
 
     //@author OscarWang114
-    public void setContractPath(String contractPath) {
-        this.contractPath.set(requireNonNull(contractPath));
+    public void setContractName(String contractName) {
+        this.contractName.set(requireNonNull(contractName));
     }
 
     @Override
-    public StringProperty contractPathProperty() {
-        return contractPath;
+    public StringProperty contractNameProperty() {
+        return contractName;
     }
 
     @Override
-    public String getContractPath() {
-        return contractPath.get();
+    public String getContractName() {
+        return contractName.get();
     }
 
     public void setSigningDateString(String signingDateString) throws IllegalValueException {

--- a/src/main/java/seedu/address/model/insurance/ReadOnlyInsurance.java
+++ b/src/main/java/seedu/address/model/insurance/ReadOnlyInsurance.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.StringProperty;
-import seedu.address.model.person.ReadOnlyPerson;
 
 //@@author OscarWang114
 /**

--- a/src/main/java/seedu/address/model/insurance/ReadOnlyInsurance.java
+++ b/src/main/java/seedu/address/model/insurance/ReadOnlyInsurance.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.StringProperty;
+import seedu.address.model.person.ReadOnlyPerson;
 
 //@@author OscarWang114
 /**
@@ -37,6 +38,22 @@ public interface ReadOnlyInsurance {
     String getSigningDateString();
     StringProperty expiryDateStringProperty();
     String getExpiryDateString();
+
+    /**
+     * Returns true if both have the same state. (interfaces cannot override .equals)
+     */
+    default boolean isSameStateAs(ReadOnlyInsurance other) {
+        return other == this // short circuit if same object
+                || (other != null // this is first to avoid NPE below
+                && other.getId().equals(this.getId()) // state checks here onwards
+                && other.getOwnerName().equals(this.getOwnerName())
+                && other.getInsuredName().equals(this.getInsuranceName())
+                && other.getBeneficiaryName().equals(this.getBeneficiaryName())
+                && other.getPremium().equals(this.getPremium())
+                && other.getSigningDateString().equals(this.getSigningDateString())
+                && other.getExpiryDateString().equals(this.getExpiryDateString()))
+                && other.getContractName().equals(this.getContractName());
+    }
 
     /**
      * Formats the insurance as text, showing all the details.

--- a/src/main/java/seedu/address/model/insurance/ReadOnlyInsurance.java
+++ b/src/main/java/seedu/address/model/insurance/ReadOnlyInsurance.java
@@ -31,8 +31,8 @@ public interface ReadOnlyInsurance {
     Double getPremium();
     StringProperty premiumStringProperty();
     String getPremiumString();
-    StringProperty contractPathProperty();
-    String getContractPath();
+    StringProperty contractNameProperty();
+    String getContractName();
     StringProperty signingDateStringProperty();
     String getSigningDateString();
     StringProperty expiryDateStringProperty();
@@ -53,7 +53,7 @@ public interface ReadOnlyInsurance {
                 .append(" \nPremium: ")
                 .append(getPremiumString())
                 .append("  Contract File: ")
-                .append(getContractPath())
+                .append(getContractName())
                 .append("  Signing Date: ")
                 .append(getSigningDateString())
                 .append("  Expiry Date: ")

--- a/src/main/java/seedu/address/model/insurance/UniqueLifeInsuranceMap.java
+++ b/src/main/java/seedu/address/model/insurance/UniqueLifeInsuranceMap.java
@@ -51,7 +51,7 @@ public class UniqueLifeInsuranceMap {
      */
     public boolean containsContractName(String toCheck) {
         requireNonNull(toCheck);
-        return internalMap.values().stream().anyMatch( li ->
+        return internalMap.values().stream().anyMatch(li ->
             li.getContractName().equals(toCheck)
         );
     }

--- a/src/main/java/seedu/address/model/insurance/UniqueLifeInsuranceMap.java
+++ b/src/main/java/seedu/address/model/insurance/UniqueLifeInsuranceMap.java
@@ -12,6 +12,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import seedu.address.commons.util.CollectionUtil;
+import seedu.address.model.insurance.exceptions.DuplicateInsuranceContractNameException;
 import seedu.address.model.insurance.exceptions.DuplicateInsuranceException;
 import seedu.address.model.insurance.exceptions.InsuranceNotFoundException;
 
@@ -30,7 +31,7 @@ public class UniqueLifeInsuranceMap {
     private final ObservableList<ReadOnlyInsurance> internalList = FXCollections.observableArrayList();
 
     /**
-     * Returns true if the map contains an equivalent UUID as the given argument.
+     * Returns true if the map contains an equivalent key {@code UUID} as the given argument.
      */
     public boolean containsKey(UUID toCheck) {
         requireNonNull(toCheck);
@@ -38,11 +39,21 @@ public class UniqueLifeInsuranceMap {
     }
 
     /**
-     * Returns true if the map contains an equivalent insurance as the given argument.
+     * Returns true if the map contains an equivalent value {@code ReadOnlyInsurance} as the given argument.
      */
     public boolean containsValue(ReadOnlyInsurance toCheck) {
         requireNonNull(toCheck);
         return internalMap.containsValue(toCheck);
+    }
+
+    /**
+     * Returns true if an insurance inside the map contains an equivalent {@code contractName} as the given argument.
+     */
+    public boolean containsContractName(String toCheck) {
+        requireNonNull(toCheck);
+        return internalMap.values().stream().anyMatch( li ->
+            li.getContractName().equals(toCheck)
+        );
     }
 
     /**
@@ -51,16 +62,20 @@ public class UniqueLifeInsuranceMap {
      * @throws DuplicateInsuranceException if the life insurance to add is a duplicate of an
      * existing life insurance in the map.
      */
-    public void put(UUID key, ReadOnlyInsurance toPut) throws DuplicateInsuranceException {
+    public void put(UUID key, ReadOnlyInsurance toPut)
+            throws DuplicateInsuranceException, DuplicateInsuranceContractNameException {
         requireNonNull(toPut);
         if (containsValue(toPut)) {
             throw new DuplicateInsuranceException();
+        }
+        if (containsContractName(toPut.getContractName())) {
+            throw new DuplicateInsuranceContractNameException();
         }
         internalMap.put(key, new LifeInsurance(toPut));
     }
 
     /**
-     * Replaces an life insurance to the map.
+     * Replaces an life insurance in the map.
      *
      * @throws InsuranceNotFoundException if the id of the life insurance {@code toSet} can not be found
      * in the map.
@@ -97,7 +112,8 @@ public class UniqueLifeInsuranceMap {
         syncMappedListWithInternalMap();
     }
 
-    public void setInsurances(Map<UUID, ? extends ReadOnlyInsurance> insurances) throws DuplicateInsuranceException {
+    public void setInsurances(Map<UUID, ? extends ReadOnlyInsurance> insurances)
+            throws DuplicateInsuranceException, DuplicateInsuranceContractNameException {
         final UniqueLifeInsuranceMap replacement = new UniqueLifeInsuranceMap();
         for (final Map.Entry<UUID, ? extends ReadOnlyInsurance> entry : insurances.entrySet()) {
             replacement.put(entry.getKey(), entry.getValue());

--- a/src/main/java/seedu/address/model/insurance/exceptions/DuplicateInsuranceContractNameException.java
+++ b/src/main/java/seedu/address/model/insurance/exceptions/DuplicateInsuranceContractNameException.java
@@ -1,0 +1,13 @@
+package seedu.address.model.insurance.exceptions;
+
+import seedu.address.commons.exceptions.DuplicateDataException;
+
+//@@author OscarWang114
+/**
+ * Signals that the operation will result in duplicate Insurance objects.
+ */
+public class DuplicateInsuranceContractNameException extends DuplicateDataException {
+    public DuplicateInsuranceContractNameException() {
+        super("Operation would result in duplicate insurance contract names");
+    }
+}

--- a/src/main/java/seedu/address/storage/XmlAdaptedLifeInsurance.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedLifeInsurance.java
@@ -24,7 +24,7 @@ public class XmlAdaptedLifeInsurance {
     @XmlElement(required = true)
     private Double premium;
     @XmlElement(required = true)
-    private String contractPath;
+    private String contractName;
     @XmlElement(required = true)
     private String signingDate;
     @XmlElement(required = true)
@@ -49,7 +49,7 @@ public class XmlAdaptedLifeInsurance {
         insured = source.getInsured().getName();
         beneficiary = source.getBeneficiary().getName();
         premium = source.getPremium();
-        contractPath = source.getContractName();
+        contractName = source.getContractName();
         signingDate = source.getSigningDateString();
         expiryDate = source.getExpiryDateString();
     }
@@ -62,6 +62,6 @@ public class XmlAdaptedLifeInsurance {
 
     public LifeInsurance toModelType() throws IllegalValueException {
         return new LifeInsurance(this.id, this.insuranceName, this.owner, this.insured, this.beneficiary, this.premium,
-                this.contractPath, this.signingDate, this.expiryDate);
+                this.contractName, this.signingDate, this.expiryDate);
     }
 }

--- a/src/main/java/seedu/address/storage/XmlAdaptedLifeInsurance.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedLifeInsurance.java
@@ -49,7 +49,7 @@ public class XmlAdaptedLifeInsurance {
         insured = source.getInsured().getName();
         beneficiary = source.getBeneficiary().getName();
         premium = source.getPremium();
-        contractPath = source.getContractPath();
+        contractPath = source.getContractName();
         signingDate = source.getSigningDateString();
         expiryDate = source.getExpiryDateString();
     }

--- a/src/main/java/seedu/address/ui/InsuranceCard.java
+++ b/src/main/java/seedu/address/ui/InsuranceCard.java
@@ -15,13 +15,13 @@ import seedu.address.commons.events.ui.PersonNameClickedEvent;
 import seedu.address.commons.events.ui.SwitchToInsurancePanelRequestEvent;
 import seedu.address.model.insurance.ReadOnlyInsurance;
 
-
+//@@author OscarWang114
 /**
  * An UI component that displays information of a {@code LifeInsurance}.
  */
 public class InsuranceCard extends UiPart<Region> {
 
-    //@@author OscarWang114
+
     private static final String FXML = "InsuranceCard.fxml";
     private final Logger logger = LogsCenter.getLogger(this.getClass());
 

--- a/src/main/java/seedu/address/ui/InsuranceProfilePanel.java
+++ b/src/main/java/seedu/address/ui/InsuranceProfilePanel.java
@@ -105,7 +105,7 @@ public class InsuranceProfilePanel extends UiPart<Region> {
      */
 
     private void initializeContractFile(ReadOnlyInsurance insurance) {
-        insuranceFile =  new File(PDFFOLDERPATH + insurance.getContractPath());
+        insuranceFile =  new File(PDFFOLDERPATH + insurance.getContractName());
         if (isFileExists(insuranceFile)) {
             activateLinkToInsuranceFile();
         } else {
@@ -144,7 +144,7 @@ public class InsuranceProfilePanel extends UiPart<Region> {
             try {
                 Desktop.getDesktop().open(insuranceFile);
             } catch (IOException ee) {
-                logger.info("File do not exist: " + PDFFOLDERPATH + insurance.getContractPath());
+                logger.info("File do not exist: " + PDFFOLDERPATH + insurance.getContractName());
             }
         });
     }
@@ -160,7 +160,7 @@ public class InsuranceProfilePanel extends UiPart<Region> {
         owner.textProperty().bind(Bindings.convert(insurance.getOwner().nameProperty()));
         insured.textProperty().bind(Bindings.convert(insurance.getInsured().nameProperty()));
         beneficiary.textProperty().bind(Bindings.convert(insurance.getBeneficiary().nameProperty()));
-        contractPath.textProperty().bind(Bindings.convert(insurance.contractPathProperty()));
+        contractPath.textProperty().bind(Bindings.convert(insurance.contractNameProperty()));
         premium.textProperty().bind(Bindings.convert(insurance.premiumStringProperty()));
         signingDate.textProperty().bind(Bindings.convert(insurance.signingDateStringProperty()));
         expiryDate.textProperty().bind(Bindings.convert(insurance.expiryDateStringProperty()));

--- a/src/main/java/seedu/address/ui/InsuranceProfilePanel.java
+++ b/src/main/java/seedu/address/ui/InsuranceProfilePanel.java
@@ -57,7 +57,7 @@ public class InsuranceProfilePanel extends UiPart<Region> {
     @FXML
     private Label expiryDate;
     @FXML
-    private Label contractPath;
+    private Label contractName;
 
     public InsuranceProfilePanel() {
         super(FXML);
@@ -109,9 +109,9 @@ public class InsuranceProfilePanel extends UiPart<Region> {
         if (isFileExists(insuranceFile)) {
             activateLinkToInsuranceFile();
         } else {
-            contractPath.getStyleClass().clear();
-            contractPath.getStyleClass().add("missing-file");
-            contractPath.setOnMouseClicked(new EventHandler<MouseEvent>() {
+            contractName.getStyleClass().clear();
+            contractName.getStyleClass().add("missing-file");
+            contractName.setOnMouseClicked(new EventHandler<MouseEvent>() {
                 @Override
                 public void handle(MouseEvent event) {
                     FileChooser.ExtensionFilter extFilter =
@@ -138,9 +138,9 @@ public class InsuranceProfilePanel extends UiPart<Region> {
      *  Enable the link to open contract pdf file and adjusting the text hover highlight
      */
     private void activateLinkToInsuranceFile() {
-        contractPath.getStyleClass().clear();
-        contractPath.getStyleClass().add("valid-file");
-        contractPath.setOnMouseClicked(event -> {
+        contractName.getStyleClass().clear();
+        contractName.getStyleClass().add("valid-file");
+        contractName.setOnMouseClicked(event -> {
             try {
                 Desktop.getDesktop().open(insuranceFile);
             } catch (IOException ee) {
@@ -160,7 +160,7 @@ public class InsuranceProfilePanel extends UiPart<Region> {
         owner.textProperty().bind(Bindings.convert(insurance.getOwner().nameProperty()));
         insured.textProperty().bind(Bindings.convert(insurance.getInsured().nameProperty()));
         beneficiary.textProperty().bind(Bindings.convert(insurance.getBeneficiary().nameProperty()));
-        contractPath.textProperty().bind(Bindings.convert(insurance.contractNameProperty()));
+        contractName.textProperty().bind(Bindings.convert(insurance.contractNameProperty()));
         premium.textProperty().bind(Bindings.convert(insurance.premiumStringProperty()));
         signingDate.textProperty().bind(Bindings.convert(insurance.signingDateStringProperty()));
         expiryDate.textProperty().bind(Bindings.convert(insurance.expiryDateStringProperty()));

--- a/src/main/resources/view/InsuranceProfilePanel.fxml
+++ b/src/main/resources/view/InsuranceProfilePanel.fxml
@@ -32,7 +32,7 @@
                               <Label fx:id="owner" styleClass="dynamic-labels" text="\$owner" />
                               <Label fx:id="insured" styleClass="dynamic-labels" text="\$insured" />
                               <Label fx:id="beneficiary" styleClass="dynamic-labels" text="\$beneficiary" />
-                              <Label fx:id="contractPath" styleClass="dynamic-labels" text="\$contractPath" />
+                              <Label fx:id="contractName" styleClass="dynamic-labels" text="\$contractName" />
                               <Label fx:id="premium" styleClass="dynamic-labels" text="\$premium" />
                               <Label fx:id="signingDate" styleClass="dynamic-labels" text="\$signingDate" />
                               <Label fx:id="expiryDate" styleClass="dynamic-labels" text="\$expiryDate" />

--- a/src/test/java/seedu/address/logic/parser/AddLifeInsuranceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLifeInsuranceCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BENEFICIARY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -31,7 +31,7 @@ public class AddLifeInsuranceCommandParserTest {
         assertCommandFail(parser, command);
         command += " " + PREFIX_PREMIUM + 493.34;
         assertCommandFail(parser, command);
-        command += " " + PREFIX_CONTRACT + "contract.pdf";
+        command += " " + PREFIX_CONTRACT_NAME + "contract.pdf";
         assertCommandFail(parser, command);
         command += " " + PREFIX_SIGNING_DATE + "01 11 2011";
         assertCommandFail(parser, command);


### PR DESCRIPTION
- Ensure that there are no duplicate insurance contract names inside LISA. A `DuplicateInsuranceContractNameException` is thrown when adding an insurance that violates this rule.
- Update version of LISA in `MainApp`
- Rename `contractPath` to `contractName` to represent the variable more accurately
- Minor Style Fix